### PR TITLE
Fix crash application with RecyclerViewFastScroller when using lazy initialization of RecyclerView

### DIFF
--- a/Application/src/main/java/xyz/danoz/recyclerviewfastscroller/sample/fragment/RecyclerViewWithFastScrollerFragment.java
+++ b/Application/src/main/java/xyz/danoz/recyclerviewfastscroller/sample/fragment/RecyclerViewWithFastScrollerFragment.java
@@ -48,16 +48,16 @@ public class RecyclerViewWithFastScrollerFragment extends Fragment {
         RecyclerView recyclerView = (RecyclerView) rootView.findViewById(R.id.recycler_view);
         VerticalRecyclerViewFastScroller fastScroller = (VerticalRecyclerViewFastScroller) rootView.findViewById(R.id.fast_scroller);
 
-//        // Connect the recycler to the scroller (to let the scroller scroll the list)
-//        fastScroller.setRecyclerView(recyclerView);
-//
-//        // Connect the scroller to the recycler (to let the recycler scroll the scroller's handle)
-//        recyclerView.addOnScrollListener(fastScroller.getOnScrollListener());
-//
-//        setRecyclerViewLayoutManager(recyclerView);
-//
-//        RecyclerView.Adapter adapter = new ColorfulAdapter(new ColorDataSet());
-//        recyclerView.setAdapter(adapter);
+        // Connect the recycler to the scroller (to let the scroller scroll the list)
+        fastScroller.setRecyclerView(recyclerView);
+
+        // Connect the scroller to the recycler (to let the recycler scroll the scroller's handle)
+        recyclerView.addOnScrollListener(fastScroller.getOnScrollListener());
+
+        setRecyclerViewLayoutManager(recyclerView);
+
+        RecyclerView.Adapter adapter = new ColorfulAdapter(new ColorDataSet());
+        recyclerView.setAdapter(adapter);
 
         return rootView;
     }

--- a/Application/src/main/java/xyz/danoz/recyclerviewfastscroller/sample/fragment/RecyclerViewWithFastScrollerFragment.java
+++ b/Application/src/main/java/xyz/danoz/recyclerviewfastscroller/sample/fragment/RecyclerViewWithFastScrollerFragment.java
@@ -48,16 +48,16 @@ public class RecyclerViewWithFastScrollerFragment extends Fragment {
         RecyclerView recyclerView = (RecyclerView) rootView.findViewById(R.id.recycler_view);
         VerticalRecyclerViewFastScroller fastScroller = (VerticalRecyclerViewFastScroller) rootView.findViewById(R.id.fast_scroller);
 
-        // Connect the recycler to the scroller (to let the scroller scroll the list)
-        fastScroller.setRecyclerView(recyclerView);
-
-        // Connect the scroller to the recycler (to let the recycler scroll the scroller's handle)
-        recyclerView.addOnScrollListener(fastScroller.getOnScrollListener());
-
-        setRecyclerViewLayoutManager(recyclerView);
-
-        RecyclerView.Adapter adapter = new ColorfulAdapter(new ColorDataSet());
-        recyclerView.setAdapter(adapter);
+//        // Connect the recycler to the scroller (to let the scroller scroll the list)
+//        fastScroller.setRecyclerView(recyclerView);
+//
+//        // Connect the scroller to the recycler (to let the recycler scroll the scroller's handle)
+//        recyclerView.addOnScrollListener(fastScroller.getOnScrollListener());
+//
+//        setRecyclerViewLayoutManager(recyclerView);
+//
+//        RecyclerView.Adapter adapter = new ColorfulAdapter(new ColorDataSet());
+//        recyclerView.setAdapter(adapter);
 
         return rootView;
     }

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -29,23 +29,31 @@ import xyz.danoz.recyclerviewfastscroller.sectionindicator.SectionIndicator;
 /**
  * Defines a basic widget that will allow for fast scrolling a RecyclerView using the basic paradigm of
  * a handle and a bar.
- *
+ * <p>
  * TODO: More specifics and better support for effectively extending this base class
  */
 public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements RecyclerViewScroller {
 
-    /** Animation **/
+    /**
+     * Animation
+     **/
     private static final int DURATION_FADE_IN = 150;
     private static final int DURATION_FADE_OUT = 300;
     private static final int FADE_TIMEOUT = 1500;
     private HideHandler mHideHandler;
 
     private static final int[] STYLEABLE = R.styleable.AbsRecyclerViewFastScroller;
-    /** The long bar along which a handle travels */
+    /**
+     * The long bar along which a handle travels
+     */
     protected final View mBar;
-    /** The handle that signifies the user's progress in the list */
+    /**
+     * The handle that signifies the user's progress in the list
+     */
     protected final View mHandle;
-    /** A special listener that corresponds to when the user is grabbing the handle */
+    /**
+     * A special listener that corresponds to when the user is grabbing the handle
+     */
     protected FastScrollListener mFastScrollListener;
 
     /* TODO:
@@ -55,8 +63,10 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     private RecyclerView mRecyclerView;
     private SectionIndicator mSectionIndicator;
 
-    /** If I had my druthers, AbsRecyclerViewFastScroller would implement this as an interface, but Android has made
-     * {@link OnScrollListener} an abstract class instead of an interface. Hmmm */
+    /**
+     * If I had my druthers, AbsRecyclerViewFastScroller would implement this as an interface, but Android has made
+     * {@link OnScrollListener} an abstract class instead of an interface. Hmmm
+     */
     protected OnScrollListener mOnScrollListener;
 
     private boolean shouldCreateScrollProgressCalculator;
@@ -131,6 +141,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
 
     /**
      * Provides the ability to programmatically set the color of the fast scroller's handle
+     *
      * @param color for the handle to be
      */
     public void setHandleColor(int color) {
@@ -139,6 +150,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
 
     /**
      * Provides the ability to programmatically set the background drawable of the fast scroller's handle
+     *
      * @param drawable for the handle's background
      */
     public void setHandleBackground(Drawable drawable) {
@@ -147,6 +159,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
 
     /**
      * Provides the ability to programmatically set the color of the fast scroller's bar
+     *
      * @param color for the bar to be
      */
     public void setBarColor(int color) {
@@ -155,6 +168,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
 
     /**
      * Provides the ability to programmatically set the background drawable of the fast scroller's bar
+     *
      * @param drawable for the bar's background
      */
     public void setBarBackground(Drawable drawable) {
@@ -188,6 +202,11 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     @Override
     public void scrollTo(float scrollProgress, boolean fromTouch) {
         int position = getPositionFromScrollProgress(scrollProgress);
+
+        if (mRecyclerView == null) {
+            return;
+        }
+
         mRecyclerView.scrollToPosition(position);
 
         updateSectionIndicator(position, scrollProgress);
@@ -206,12 +225,13 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     }
 
     private int getPositionFromScrollProgress(float scrollProgress) {
-        return (int) (mRecyclerView.getAdapter().getItemCount() * scrollProgress);
+        return mRecyclerView == null ? 0 : (int) (mRecyclerView.getAdapter().getItemCount() * scrollProgress);
     }
 
     /**
      * Classes that extend AbsFastScroller must implement their own {@link OnScrollListener} to respond to scroll
      * events when the {@link #mRecyclerView} is scrolled NOT using the fast scroller.
+     *
      * @return an implementation for responding to scroll events from the {@link #mRecyclerView}
      */
     @NonNull
@@ -232,7 +252,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
                     // While dragging, always show the handle.
                     if (newState == RecyclerView.SCROLL_STATE_DRAGGING)
                         show(0);
-                    // Once dragging stops, show the handle only a little more, then fade out.
+                        // Once dragging stops, show the handle only a little more, then fade out.
                     else if (newState == RecyclerView.SCROLL_STATE_IDLE)
                         show(FADE_TIMEOUT);
                 }
@@ -252,6 +272,10 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
 
+        if (mRecyclerView == null) {
+            return;
+        }
+
         if (getScrollProgressCalculator() == null || shouldCreateScrollProgressCalculator) {
             shouldCreateScrollProgressCalculator = false;
             onCreateScrollProgressCalculator();
@@ -269,6 +293,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
 
     /**
      * Takes a touch event and determines how much scroll progress this translates into
+     *
      * @param event touch event received by the layout
      * @return scroll progress, or fraction by which list is scrolled [0 to 1]
      */
@@ -283,12 +308,14 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     /**
      * Define a layout resource for your implementation of AbsFastScroller
      * Currently must contain a handle view (R.id.scroll_handle) and a bar (R.id.scroll_bar)
+     *
      * @return a resource id corresponding to the chosen layout.
      */
     protected abstract int getLayoutResourceId();
 
     /**
      * Define a ScrollProgressCalculator for your implementation of AbsFastScroller
+     *
      * @return a chosen implementation of {@link ScrollProgressCalculator}
      */
     @Nullable
@@ -296,14 +323,15 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
 
     /**
      * Moves the handle of the scroller by specific progress amount
+     *
      * @param scrollProgress fraction by which to move scroller [0 to 1]
      */
     public abstract void moveHandleToPosition(float scrollProgress);
 
     private void show(int timeout) {
         animate()
-            .alpha(1f)
-            .setDuration(DURATION_FADE_IN);
+                .alpha(1f)
+                .setDuration(DURATION_FADE_IN);
 
         Message msg = mHideHandler.obtainMessage(1);
         mHideHandler.removeMessages(1);

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -29,7 +29,6 @@ import xyz.danoz.recyclerviewfastscroller.sectionindicator.SectionIndicator;
 /**
  * Defines a basic widget that will allow for fast scrolling a RecyclerView using the basic paradigm of
  * a handle and a bar.
- * <p>
  * TODO: More specifics and better support for effectively extending this base class
  */
 public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements RecyclerViewScroller {


### PR DESCRIPTION
Scroller produced NullPointerException if RecyclerView was not set onCreate or adapter not set for RecyclerView. I add check on null for mRecyclerView field.
